### PR TITLE
Add support for documentDB

### DIFF
--- a/src/main/java/org/eclipse/ecsp/nosqldao/NoSqlDatabaseType.java
+++ b/src/main/java/org/eclipse/ecsp/nosqldao/NoSqlDatabaseType.java
@@ -53,7 +53,11 @@ public enum NoSqlDatabaseType {
     /**
      * CosmosDB database type.
      */
-    COSMOSDB("cosmosDB");
+    COSMOSDB("cosmosDB"),
+    /**
+     * DocumentDB database type.
+     */
+    DOCUMENTDB("documentDB");
 
     /**
      * The database type.
@@ -83,6 +87,9 @@ public enum NoSqlDatabaseType {
                 break;
             case "cosmosDB":
                 dbTypeEnum = NoSqlDatabaseType.COSMOSDB;
+                break;
+            case "documentDB":
+                dbTypeEnum = NoSqlDatabaseType.DOCUMENTDB;
                 break;
             default:
                 throw new UnsupportedDatabaseTypeException("Unsupported database type : " + dbType);

--- a/src/main/java/org/eclipse/ecsp/nosqldao/mongodb/IgniteBaseDAOMongoImpl.java
+++ b/src/main/java/org/eclipse/ecsp/nosqldao/mongodb/IgniteBaseDAOMongoImpl.java
@@ -41,6 +41,7 @@
 package org.eclipse.ecsp.nosqldao.mongodb;
 
 import com.google.common.reflect.TypeToken;
+import com.mongodb.MongoCommandException;
 import com.mongodb.client.DistinctIterable;
 import com.mongodb.client.ListIndexesIterable;
 import com.mongodb.client.MongoCollection;
@@ -76,6 +77,7 @@ import org.eclipse.ecsp.nosqldao.IgniteCriteriaGroup;
 import org.eclipse.ecsp.nosqldao.IgnitePagingInfoResponse;
 import org.eclipse.ecsp.nosqldao.IgniteQuery;
 import org.eclipse.ecsp.nosqldao.MongoDiagnosticReporterImpl;
+import org.eclipse.ecsp.nosqldao.NoSqlDatabaseType;
 import org.eclipse.ecsp.nosqldao.Operator;
 import org.eclipse.ecsp.nosqldao.QueryTranslator;
 import org.eclipse.ecsp.nosqldao.Updates;
@@ -187,6 +189,18 @@ public abstract class IgniteBaseDAOMongoImpl<K, E extends IgniteEntity> implemen
     private boolean daoMetricsEnabled;
 
     /**
+     * The maximum number of attempts to ensure the DocumentDB index.
+     */
+    @Value("${" + PropertyNames.DOCUMENTDB_INDEX_ENSURE_MAX_ATTEMPTS + ":2}")
+    private int indexEnsureMaxAttempts;
+
+    /**
+     * The backoff time in milliseconds for ensuring the DocumentDB index.
+     */
+    @Value("${" + PropertyNames.DOCUMENTDB_INDEX_ENSURE_BACKOFF_BASE_MS + ":100}")
+    private long indexEnsureBackoffBaseMs;
+
+    /**
      * The name of the entity class.
      */
     private String entityClassName;
@@ -201,6 +215,25 @@ public abstract class IgniteBaseDAOMongoImpl<K, E extends IgniteEntity> implemen
      * The map of shard keys.
      */
     private Map<String, List<String>> shardKeyMap;
+
+    /**
+     * The NoSQL database type.
+     */
+    protected NoSqlDatabaseType noSqlDatabaseType;
+
+    /**
+     * Setter for reading property and assigning appropriate enumeration for database type.
+     * @param noSqlDatabaseTypeStr : String
+     */
+    @Autowired
+    public void setNoSqlDatabaseType(@Value("${" + PropertyNames.NO_SQL_DATABASE_TYPE + ":}")
+                                     String noSqlDatabaseTypeStr) {
+        if (StringUtils.isBlank(noSqlDatabaseTypeStr)) {
+            noSqlDatabaseType = NoSqlDatabaseType.MONGODB;
+        } else {
+            noSqlDatabaseType = NoSqlDatabaseType.valueOf(noSqlDatabaseTypeStr.toUpperCase());
+        }
+    }
 
     /**
      * Instantiates a new Ignite base DAO Mongo.
@@ -257,15 +290,23 @@ public abstract class IgniteBaseDAOMongoImpl<K, E extends IgniteEntity> implemen
         updatesTranslator = new UpdatesTranslatorMorphiaImpl();
         String overridingCollection = getOverridingCollectionName();
         if (StringUtils.isEmpty(overridingCollection)) {
-            mongoDatastore.ensureIndexes(entityClass);
+            if (noSqlDatabaseType == NoSqlDatabaseType.DOCUMENTDB) {
+                ensureIndexesWithRetryForEntityClass();
+            } else {
+                mongoDatastore.ensureIndexes(entityClass);
+            }
             if (diagnosticMongoReporterEnabled) {
                 collection = mongoDatastore.getMapper().getCollection(entityClass);
             }
         } else {
             EntityModel model = mongoDatastore.getMapper().getEntityModel(entityClass);
             IndexHelper indexHelper = new IndexHelper(mongoDatastore.getMapper());
-            indexHelper.createIndex(mongoDatastore.getDatabase().getCollection(
-                    overridingCollection, entityClass), model);
+            if (noSqlDatabaseType == NoSqlDatabaseType.DOCUMENTDB) {
+                ensureIndexesWithRetryForOverride(indexHelper, model, overridingCollection);
+            } else {
+                indexHelper.createIndex(
+                    mongoDatastore.getDatabase().getCollection(overridingCollection, entityClass), model);
+            }
             if (diagnosticMongoReporterEnabled) {
                 collection = mongoDatastore.getDatabase().getCollection(overridingCollection);
             }
@@ -290,6 +331,92 @@ public abstract class IgniteBaseDAOMongoImpl<K, E extends IgniteEntity> implemen
         }
         initializeMetricsObjects();
         loadShardKeys();
+    }
+
+    /**
+     * Create collection and swallow NamespaceExists in concurrent starts.
+     */
+    private void safeCreateCollection(String collectionName) {
+        try {
+            mongoDatastore.getDatabase().createCollection(collectionName);
+            LOGGER.info("Created collection: {}", collectionName);
+        } catch (MongoCommandException mce) {
+            // 48 = NamespaceExists
+            if (mce.getErrorCode() == NumericConstants.FORTY_EIGHT 
+                    || String.valueOf(mce.getErrorCode()).equals(String.valueOf(NumericConstants.FORTY_EIGHT))) {
+                LOGGER.info("Collection {} already exists (race); continuing", collectionName);
+            } else {
+                throw mce;
+            }
+        }
+    }
+
+    /**
+     * Common retry helper for ensuring/creating indexes that may race with collection creation.
+     * Retries on Mongo error codes 26 (NamespaceNotFound) and 85 (implicit creation not supported).
+     *
+     * @param collectionName the name of the collection to create if missing
+     * @param indexCreationAction the action that creates indexes
+     */
+    private void ensureIndexesWithRetry(String collectionName, Runnable indexCreationAction) {
+        final int MAX_ATTEMPTS = Math.max(1, indexEnsureMaxAttempts);
+        int attempt = 0;
+        while (true) {
+            try {
+                indexCreationAction.run();
+                return;
+            } catch (MongoCommandException mce) {
+                int code = mce.getErrorCode();
+                boolean retryable = code == NumericConstants.TWENTY_SIX || code == NumericConstants.EIGHTY_FIVE;
+                if (retryable && attempt < MAX_ATTEMPTS - 1) {
+                    attempt++;
+                    LOGGER.warn("Index creation failed for {} with code {}; "
+                        + "creating collection and retrying (attempt {}/{})",
+                        collectionName, code, attempt, MAX_ATTEMPTS);
+                    safeCreateCollection(collectionName);
+                    backoff(attempt);
+                } else {
+                    throw mce;
+                }
+            }
+        }
+    }
+
+    /**
+     * Ensure indexes for entity class with retry if collection isn't present yet.
+     * Concurrency-safe ensure indexes with catch-and-retry if collection creation races across pods.
+     */
+    private void ensureIndexesWithRetryForEntityClass() {
+        MongoCollection<E> coll = mongoDatastore.getMapper().getCollection(entityClass);
+        String collName = coll.getNamespace().getCollectionName();
+        ensureIndexesWithRetry(collName, () -> mongoDatastore.ensureIndexes(entityClass));
+    }
+
+    /**
+     * Ensure indexes for overriding collection with retry if collection isn't present yet.
+     *
+     * @param indexHelper the index helper to create indexes
+     * @param model the entity model
+     * @param overridingCollection the name of the overriding collection
+     */
+    private void ensureIndexesWithRetryForOverride(IndexHelper indexHelper, 
+            EntityModel model, String overridingCollection) {
+        ensureIndexesWithRetry(
+            overridingCollection,
+            () -> indexHelper.createIndex(
+                mongoDatastore.getDatabase().getCollection(overridingCollection, entityClass), model));
+    }
+
+    /**
+     * Backoff strategy for retrying operations.
+     * @param attempt the current attempt number
+     */
+    private void backoff(int attempt) {
+        try {
+            Thread.sleep(indexEnsureBackoffBaseMs * attempt);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     /**

--- a/src/main/java/org/eclipse/ecsp/nosqldao/spring/config/AbstractIgniteDAOMongoConfig.java
+++ b/src/main/java/org/eclipse/ecsp/nosqldao/spring/config/AbstractIgniteDAOMongoConfig.java
@@ -42,7 +42,11 @@ package org.eclipse.ecsp.nosqldao.spring.config;
 
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoCredential;
+import com.mongodb.ReadPreference;
 import com.mongodb.ServerAddress;
+import com.mongodb.Tag;
+import com.mongodb.TagSet;
 import com.mongodb.client.MongoClient;
 import dev.morphia.AdvancedDatastore;
 import dev.morphia.mapping.DiscriminatorFunction;
@@ -58,6 +62,7 @@ import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.eclipse.ecsp.healthcheck.HealthMonitor;
 import org.eclipse.ecsp.nosqldao.NoSqlDatabaseType;
+import org.eclipse.ecsp.nosqldao.mongodb.MongoReadPreference;
 import org.eclipse.ecsp.nosqldao.utils.Constants;
 import org.eclipse.ecsp.nosqldao.utils.PropertyNames;
 import org.eclipse.ecsp.utils.logger.IgniteLogger;
@@ -299,6 +304,62 @@ public abstract class AbstractIgniteDAOMongoConfig implements HealthMonitor {
     protected Integer maintenanceFrequency;
 
     /**
+     * The host for DocumentDB.
+     * The default value is empty.
+     */
+    @Value("${" + PropertyNames.DOCUMENTDB_HOST + ":}")
+    protected String docDbHost;
+
+    /**
+     * The port for DocumentDB.
+     * The default value is 27017.
+     */
+    @Value("${" + PropertyNames.DOCUMENTDB_PORT + ":27017}")
+    protected int docDbPort;
+
+    /**
+     * The username for DocumentDB.
+     * The default value is empty.
+     */
+    @Value("${" + PropertyNames.DOCUMENTDB_USERNAME + ":}")
+    protected String docDbUsername;
+
+    /**
+     * The password for DocumentDB.
+     * The default value is empty.
+     */
+    @Value("${" + PropertyNames.DOCUMENTDB_PASSWORD + ":}")
+    protected String docDbPassword;
+
+    /**
+     * The name of the DocumentDB database.
+     * The default value is empty.
+     */
+    @Value("${" + PropertyNames.DOCUMENTDB_NAME + ":}")
+    protected String docDbName;
+
+    /**
+     * The connection parameters for DocumentDB.
+     * The default value is defined by PropertyNames.DOCUMENTDB_DEFAULT_CONNECTION_PARAMS.
+     */
+    @Value("${" + PropertyNames.DOCUMENTDB_CONNECTION_PARAMS + ":" 
+            + PropertyNames.DOCUMENTDB_DEFAULT_CONNECTION_PARAMS + "}")
+    protected String docDbConnectionParams;
+
+    /**
+     * The authentication database for DocumentDB.
+     * The default value is admin.
+     */
+    @Value("${" + PropertyNames.DOCUMENTDB_AUTH_DB + ":admin}")
+    protected String docDbAuthDb;
+
+    /**
+     * Custom connection pool listener.
+     */
+    @Autowired
+    private CustomConnectionPoolListener customConnectionPoolListener;
+
+    /**
      * Type of NoSQL database.
      */
     protected NoSqlDatabaseType noSqlDatabaseType;
@@ -429,6 +490,18 @@ public abstract class AbstractIgniteDAOMongoConfig implements HealthMonitor {
     }
 
     /**
+     * Gets the MongoDB credentials.
+     * @return the MongoCredential
+     */
+    protected MongoCredential getCredentials() {
+        if (noSqlDatabaseType == NoSqlDatabaseType.DOCUMENTDB) {
+            return MongoCredential.createCredential(docDbUsername, docDbAuthDb,
+                    docDbPassword.toCharArray());
+        }
+        return MongoCredential.createCredential(username, authDb, password.toCharArray());
+    }
+
+    /**
      * Validates the configuration properties for MongoDB and CosmosDB.
      * Throws IllegalArgumentException if any required property is missing.
      */
@@ -440,10 +513,35 @@ public abstract class AbstractIgniteDAOMongoConfig implements HealthMonitor {
             validateMongoDbAttributes(inValidConfAttributes);
         } else if (noSqlDatabaseType == NoSqlDatabaseType.COSMOSDB) {
             validateCosmosDbAttributes(inValidConfAttributes);
+        } else if (noSqlDatabaseType == NoSqlDatabaseType.DOCUMENTDB) {
+            validateDocumentDbAttributes(inValidConfAttributes);
         }
         if (!inValidConfAttributes.isEmpty()) {
             throw new IllegalArgumentException("Missing connection properties: "
                     + inValidConfAttributes.toString());
+        }
+    }
+
+    /**
+     * Validates the configuration properties for DocumentDB.
+     *
+     * @param inValidConfAttributes : List of String
+     */
+    private void validateDocumentDbAttributes(List<String> inValidConfAttributes) {
+        if (StringUtils.isBlank(docDbHost)) {
+            inValidConfAttributes.add("documentdb.host");
+        }
+        if (docDbPort == 0) {
+            inValidConfAttributes.add("documentdb.port");
+        }
+        if (StringUtils.isBlank(docDbUsername)) {
+            inValidConfAttributes.add("documentdb.username");
+        }
+        if (StringUtils.isBlank(docDbPassword)) {
+            inValidConfAttributes.add("documentdb.password");
+        }
+        if (StringUtils.isBlank(docDbAuthDb)) {
+            inValidConfAttributes.add("documentdb.auth.db");
         }
     }
 
@@ -623,12 +721,49 @@ public abstract class AbstractIgniteDAOMongoConfig implements HealthMonitor {
      */
     private MongoClientSettings.Builder getMongoClientBuilder() {
         MongoClientSettings.Builder mongoClientSettingsBuilder = MongoClientSettings.builder();
-        if (noSqlDatabaseType == NoSqlDatabaseType.COSMOSDB) {
-            applyClientSettingsForCosmosDB(mongoClientSettingsBuilder);
-        } else {
-            applyClientSettingsForMongoDB(mongoClientSettingsBuilder);
+        switch (noSqlDatabaseType) {
+            case COSMOSDB:
+                applyClientSettingsForCosmosDB(mongoClientSettingsBuilder);
+                break;
+            case DOCUMENTDB:
+                applyClientSettingsForDocumentDB(mongoClientSettingsBuilder);
+                break;
+            case MONGODB:
+            default:
+                applyClientSettingsForMongoDB(mongoClientSettingsBuilder);
+                break;
         }
+        mongoClientSettingsBuilder.applyToConnectionPoolSettings(
+            builder -> builder.addConnectionPoolListener(customConnectionPoolListener)
+        );
         return mongoClientSettingsBuilder;
+    }
+
+    /**
+     * Applies the client settings for DocumentDB.
+     *
+     * @param mongoClientSettingsBuilder MongoClientSettings.Builder instance.
+     */
+    private void applyClientSettingsForDocumentDB(MongoClientSettings.Builder mongoClientSettingsBuilder) {
+        String documentDbConnectionString = getConnectionStringForDocumentDb();
+        ConnectionString connectionString = new ConnectionString(documentDbConnectionString);
+        mongoClientSettingsBuilder.applyConnectionString(connectionString);
+        LOGGER.info("Mongo client settings applied for DocumentDB");
+    }
+
+    /**
+     * Constructs the connection string for DocumentDB.
+     *
+     * @return : String representing the connection string.
+     */
+    private String getConnectionStringForDocumentDb() {
+        StringBuilder sb = new StringBuilder(Constants.MONGODB_PREFIX);
+        sb.append(docDbHost).append(Constants.COLON).append(docDbPort)
+                .append(Constants.FRONT_SLASH).append(docDbName)
+                .append(Constants.QUESTION_MARK)
+                .append(docDbConnectionParams);
+        LOGGER.info("Document db connection string is : {}", sb);
+        return sb.toString();
     }
 
     /**
@@ -676,6 +811,13 @@ public abstract class AbstractIgniteDAOMongoConfig implements HealthMonitor {
             builder.serverSelectionTimeout(serverSelectionTimeout, TimeUnit.MILLISECONDS);
             builder.hosts(servers);
         });
+        if (taggableReadPreferenceEnabled) {
+            mongoClientSettingsBuilder
+                .readPreference(ReadPreference.secondaryPreferred(new TagSet(new Tag(readPreferenceTag, "true"))));
+        } else {
+            mongoClientSettingsBuilder
+                .readPreference(MongoReadPreference.getEnum(readPreference).getReadPreference());
+        }
         LOGGER.info("Mongo client settings applied for MongoDB");
     }
 
@@ -708,5 +850,36 @@ public abstract class AbstractIgniteDAOMongoConfig implements HealthMonitor {
      */
     private boolean isNotNull(Integer value) {
         return (value != null);
+    }
+
+    /**
+     * Returns the log target information.
+     * @return String representing the log target.
+     */
+    protected String logTarget() {
+        switch (noSqlDatabaseType) {
+            case MONGODB:
+                return "with servers=" + servers;
+            case DOCUMENTDB:
+                return "with host=" + docDbHost + ":" + docDbPort;
+            default:
+                return "";
+        }
+    }
+
+    /**
+     * Returns the database name for the datastore.
+     * @return String representing the database name.
+     */
+    protected String getDatastoreDbName() {
+        switch (noSqlDatabaseType) {
+            case COSMOSDB:
+                return cosmosdbName;
+            case DOCUMENTDB:
+                return docDbName;
+            case MONGODB:
+            default:
+                return dbName;
+        }
     }
 }

--- a/src/main/java/org/eclipse/ecsp/nosqldao/spring/config/CustomConnectionPoolListener.java
+++ b/src/main/java/org/eclipse/ecsp/nosqldao/spring/config/CustomConnectionPoolListener.java
@@ -1,0 +1,154 @@
+/*
+ *
+ *
+ *   *******************************************************************************
+ *
+ *     Copyright (c) 2023-24 Harman International
+ *
+ *
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *
+ *     you may not use this file except in compliance with the License.
+ *
+ *     You may obtain a copy of the License at
+ *
+ *
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *     See the License for the specific language governing permissions and
+ *
+ *     limitations under the License.
+ *
+ *
+ *
+ *     SPDX-License-Identifier: Apache-2.0
+ *
+ *    *******************************************************************************
+ *
+ *
+ */
+
+package org.eclipse.ecsp.nosqldao.spring.config;
+
+import com.mongodb.event.ConnectionCheckOutFailedEvent;
+import com.mongodb.event.ConnectionCheckedInEvent;
+import com.mongodb.event.ConnectionCheckedOutEvent;
+import com.mongodb.event.ConnectionClosedEvent;
+import com.mongodb.event.ConnectionCreatedEvent;
+import com.mongodb.event.ConnectionPoolClearedEvent;
+import com.mongodb.event.ConnectionPoolClosedEvent;
+import com.mongodb.event.ConnectionPoolCreatedEvent;
+import com.mongodb.event.ConnectionPoolListener;
+import org.eclipse.ecsp.utils.logger.IgniteLogger;
+import org.eclipse.ecsp.utils.logger.IgniteLoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring-managed MongoDB connection pool listener that logs key pool and
+ * connection lifecycle events. This implementation is stateless and intended
+ * for observability and troubleshooting of the MongoDB driver connection pool.
+ * <p>
+ * Typical usage wires this component into the MongoClientSettings builder so
+ * that events are emitted by the driver and captured by the application logs.
+ * </p>
+ */
+@Component
+public class CustomConnectionPoolListener implements ConnectionPoolListener {
+
+    /**
+     * Logger for emitting connection pool and connection lifecycle diagnostics.
+     */
+    private static final IgniteLogger LOGGER = IgniteLoggerFactory.getLogger(CustomConnectionPoolListener.class);
+
+    /**
+     * Invoked when a new connection pool is created by the MongoDB driver.
+     *
+     * @param event details about the created pool (e.g., settings, server ID)
+     */
+    @Override
+    public void connectionPoolCreated(final ConnectionPoolCreatedEvent event) {
+        LOGGER.info("Connection pool created: {}", event);
+    }
+
+    /**
+     * Invoked when a connection pool is closed and its resources are released.
+     *
+     * @param event details about the closed pool
+     */
+    @Override
+    public void connectionPoolClosed(final ConnectionPoolClosedEvent event) {
+        LOGGER.info("Connection pool closed: {}", event);
+    }
+
+    /**
+     * Invoked when a connection is successfully checked out from the pool.
+     *
+     * @param event details about the checked out connection
+     */
+    @Override
+    public void connectionCheckedOut(final ConnectionCheckedOutEvent event) {
+        LOGGER.trace("Connection checked out: {}", event);
+    }
+
+    /**
+     * Invoked when a connection is returned to the pool (checked in).
+     *
+     * @param event details about the checked in connection
+     */
+    @Override
+    public void connectionCheckedIn(final ConnectionCheckedInEvent event) {
+        LOGGER.trace("Connection checked in: {}", event);
+    }
+
+    /**
+     * Invoked when a new physical connection to the server is established.
+     *
+     * @param event details about the created connection
+     */
+    @Override
+    public void connectionCreated(final ConnectionCreatedEvent event) {
+        LOGGER.trace("Connection created: {}", event);
+    }
+
+    /**
+     * Invoked when a connection is closed.
+     *
+     * @param event details about the closed connection and reason
+     */
+    @Override
+    public void connectionClosed(final ConnectionClosedEvent event) {
+        LOGGER.trace("Connection closed: {}", event);
+    }
+
+    /**
+     * Invoked when a connection checkout attempt fails.
+     *
+     * @param event details including the failure reason
+     */
+    @Override
+    public void connectionCheckOutFailed(final ConnectionCheckOutFailedEvent event) {
+        LOGGER.warn("Connection checkout failed: reason={}, event={}", event.getReason(), event);
+    }
+
+    /**
+     * Invoked when the connection pool is cleared, typically due to server
+     * state changes or error conditions.
+     *
+     * @param event details about the clearing action
+     */
+    @Override
+    public void connectionPoolCleared(final ConnectionPoolClearedEvent event) {
+        LOGGER.info("Connection pool cleared: {}", event);
+    }
+
+}

--- a/src/main/java/org/eclipse/ecsp/nosqldao/spring/config/IgniteDAOMongoConfigWithProps.java
+++ b/src/main/java/org/eclipse/ecsp/nosqldao/spring/config/IgniteDAOMongoConfigWithProps.java
@@ -42,18 +42,13 @@ package org.eclipse.ecsp.nosqldao.spring.config;
 
 import com.mongodb.MongoClientException;
 import com.mongodb.MongoClientSettings;
-import com.mongodb.MongoCredential;
 import com.mongodb.MongoException;
 import com.mongodb.MongoSocketException;
-import com.mongodb.ReadPreference;
-import com.mongodb.Tag;
-import com.mongodb.TagSet;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import dev.morphia.AdvancedDatastore;
 import dev.morphia.Morphia;
 import org.eclipse.ecsp.nosqldao.NoSqlDatabaseType;
-import org.eclipse.ecsp.nosqldao.mongodb.MongoReadPreference;
 import org.eclipse.ecsp.nosqldao.utils.NumericConstants;
 import org.eclipse.ecsp.utils.logger.IgniteLogger;
 import org.eclipse.ecsp.utils.logger.IgniteLoggerFactory;
@@ -95,26 +90,12 @@ public class IgniteDAOMongoConfigWithProps extends AbstractIgniteDAOMongoConfig 
     @Override
     protected AdvancedDatastore getDatastore() {
         mongoClient = createMongoClient();
-        String dataStoreDbName = dbName;
-        if (noSqlDatabaseType == NoSqlDatabaseType.COSMOSDB) {
-            dataStoreDbName = cosmosdbName;
-        }
         AdvancedDatastore ads = (AdvancedDatastore) Morphia.createDatastore(mongoClient, 
-                dataStoreDbName, mapperOptions);
+                getDatastoreDbName(), mapperOptions);
         mapPackagesToDatastore(ads);
         peInvocationHandler.setDatastore(ads);
         return (AdvancedDatastore) Proxy.newProxyInstance(this.getClass().getClassLoader(),
                 new Class[] { AdvancedDatastore.class }, peInvocationHandler);
-    }
-
-    /**
-     * Creates and returns MongoCredential using the provided username, authentication database, and password.
-     *
-     * @return MongoCredential instance
-     */
-    private MongoCredential getMongoCredentials() {
-        return MongoCredential.createCredential(username, authDb,
-                password.toCharArray());
     }
 
     /**
@@ -127,35 +108,25 @@ public class IgniteDAOMongoConfigWithProps extends AbstractIgniteDAOMongoConfig 
         MongoClient newMongoClient = null;
         MongoClientSettings mongoClientSettings = null;
         MongoClientSettings.Builder mongoClientSettingsBuilder = createMongoClientSettingsBuilder();
-        if (noSqlDatabaseType == NoSqlDatabaseType.MONGODB) {
-            mongoClientSettingsBuilder.credential(getMongoCredentials());
+        if (noSqlDatabaseType != NoSqlDatabaseType.COSMOSDB) {
+            mongoClientSettingsBuilder.credential(getCredentials());
         }
-        LOGGER.info("Initializing MongoClient with servers={}", servers);
+        LOGGER.info("Initializing MongoClient {}", logTarget());
         try {
-
-            if (taggableReadPreferenceEnabled) {
-                mongoClientSettings = mongoClientSettingsBuilder
-                        .readPreference(ReadPreference.secondaryPreferred(new TagSet(
-                                new Tag(readPreferenceTag, "true")))).build();
-            } else {
-                mongoClientSettings = mongoClientSettingsBuilder
-                        .readPreference(MongoReadPreference.getEnum(readPreference).getReadPreference())
-                        .build();
-            }
-
+            mongoClientSettings = mongoClientSettingsBuilder.build();
             long startTime = System.currentTimeMillis();
             newMongoClient = MongoClients.create(mongoClientSettings);
             long endTime = System.currentTimeMillis();
             setHealthy(true);
-            LOGGER.info("Initialized mongo client with servers = {} and time taken in millisec is: {}",
-                    servers, endTime - startTime);
+            LOGGER.info("Initialized mongo client {} and time taken in millisec is: {}", 
+                logTarget(), endTime - startTime);
         } catch (Exception e) {
             if (null != newMongoClient) {
                 newMongoClient.close();
             }
             setHealthy(false);
-            LOGGER.error("Failed to initialize mongodb connection", e);
-            throw new MongoConnectionException("Failed to initialize mongodb connection", e);
+            LOGGER.error("Failed to initialize database connection", e);
+            throw new MongoConnectionException("Failed to initialize database connection", e);
         }
         return newMongoClient;
     }
@@ -171,12 +142,8 @@ public class IgniteDAOMongoConfigWithProps extends AbstractIgniteDAOMongoConfig 
     public boolean isHealthy(boolean forceToRecreateClient) {
 
         if (forceToRecreateClient && (!healthy || mongoClient == null)) {
-            String dataStoreDbName = dbName;
-            if (noSqlDatabaseType == NoSqlDatabaseType.COSMOSDB) {
-                dataStoreDbName = cosmosdbName;
-            }
-            AdvancedDatastore ads = (AdvancedDatastore) Morphia.createDatastore(createMongoClient(),
-                    dataStoreDbName, mapperOptions);
+            AdvancedDatastore ads = (AdvancedDatastore) Morphia.createDatastore(
+                createMongoClient(), getDatastoreDbName(), mapperOptions);
             mapPackagesToDatastore(ads);
             peInvocationHandler.setDatastore(ads);
             setHealthy(true);

--- a/src/main/java/org/eclipse/ecsp/nosqldao/utils/Constants.java
+++ b/src/main/java/org/eclipse/ecsp/nosqldao/utils/Constants.java
@@ -177,6 +177,31 @@ public abstract class Constants {
     public static final String DISCRIMINATOR_KEY = "className";
 
     /**
+     * The discriminator value constant.
+     */
+    public static final String COLON = ":";
+
+    /**
+     * The discriminator value constant.
+     */
+    public static final String AT_THE_RATE = "@";
+
+    /**
+     * The front slash constant.
+     */
+    public static final String FRONT_SLASH = "/";
+
+    /**
+     * The question mark constant.
+     */
+    public static final String QUESTION_MARK = "?";
+
+    /**
+     * MongoDB prefix constant.
+     */
+    public static final String MONGODB_PREFIX = "mongodb://";
+
+    /**
      * Private constructor.
      */
     private Constants() {

--- a/src/main/java/org/eclipse/ecsp/nosqldao/utils/NumericConstants.java
+++ b/src/main/java/org/eclipse/ecsp/nosqldao/utils/NumericConstants.java
@@ -13,9 +13,29 @@ public class NumericConstants {
     }
 
     /**
+     * Constant for the value 1L.
+     */
+    public static final long LONG_ONE = 1L;
+
+    /**
      * Constant for the value 32.
      */
     public static final int THIRTY_TWO = 32;
+
+    /**
+     * Constant for the value 48.
+     */
+    public static final int FORTY_EIGHT = 48;
+
+    /**
+     * Constant for the value 26.
+     */
+    public static final int TWENTY_SIX = 26;
+
+    /**
+     * Constant for the value 85.
+     */
+    public static final int EIGHTY_FIVE = 85;
 
     /**
      * Constant for the value 1000.
@@ -56,6 +76,11 @@ public class NumericConstants {
      * Constant for the value 60000.
      */
     public static final int SIXTY_K = 60000;
+
+    /**
+     * Constant for the value 20L.
+     */
+    public static final long LONG_TWENTY = 20L;
 
     /**
      * Constant for the value 20000.
@@ -131,6 +156,9 @@ public class NumericConstants {
      * Constant for the value 10.
      */
     public static final int TEN = 10;
+
+    // constant for 30
+    public static final int THIRTY = 30;
 
     /**
      * Constant for the value 30000.

--- a/src/main/java/org/eclipse/ecsp/nosqldao/utils/PropertyNames.java
+++ b/src/main/java/org/eclipse/ecsp/nosqldao/utils/PropertyNames.java
@@ -212,6 +212,58 @@ public abstract class PropertyNames {
     public static final String COSMOSDB_NAME = "cosmosdb.name";
 
     /**
+     * NoSQL database type for DocumentDB property name.
+     */
+    public static final String DOCUMENTDB_NAME = "documentdb.name";
+
+    /**
+     * DocumentDB auth database property name.
+     */
+    public static final String DOCUMENTDB_AUTH_DB = "documentdb.auth.db";
+
+    /**
+     * DocumentDB connection string property name.
+     */
+    public static final String DOCUMENTDB_PORT = "documentdb.port";
+
+    /**
+     * DocumentDB host property name.
+     */
+    public static final String DOCUMENTDB_HOST = "documentdb.host";
+
+    /**
+     * DocumentDB username property name.
+     */
+    public static final String DOCUMENTDB_USERNAME = "documentdb.username";
+
+    /**
+     * DocumentDB password property name.
+     */
+    public static final String DOCUMENTDB_PASSWORD = "documentdb.password";
+
+    /**
+     * DocumentDB connection params.
+     */
+    public static final String DOCUMENTDB_CONNECTION_PARAMS = "documentdb.connection.params";
+
+    /**
+     * DocumentDB default connection params.
+     */
+    public static final String DOCUMENTDB_DEFAULT_CONNECTION_PARAMS = 
+        "tls=true&authenticationMechanism=SCRAM-SHA-1&retryWrites=false"
+            + "&readpreference=secondaryPreferred";
+
+    /**
+     * DocumentDB index ensure retry max attempts property name.
+     */
+    public static final String DOCUMENTDB_INDEX_ENSURE_MAX_ATTEMPTS = "documentdb.index.ensure.maxAttempts";
+
+    /**
+     * DocumentDB index ensure backoff base milliseconds property name.
+     */
+    public static final String DOCUMENTDB_INDEX_ENSURE_BACKOFF_BASE_MS = "documentdb.index.ensure.backoffBaseMs";
+
+    /**
      * Private constructor to prevent instantiation.
      */
     private PropertyNames() {

--- a/src/test/java/org/eclipse/ecsp/nosqldao/mongodb/IgniteBaseDAODocumentDBIntegrationTest.java
+++ b/src/test/java/org/eclipse/ecsp/nosqldao/mongodb/IgniteBaseDAODocumentDBIntegrationTest.java
@@ -94,13 +94,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 /**
- * Test Class for IgniteBaseDAOMongo operations with CosmosDB.
+ * Test Class for IgniteBaseDAODocumentDB operations with DocumentDB. 
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = { IgniteDAOMongoConfigWithProps.class })
-@TestPropertySource("/ignite-dao-cosmosdb.properties")
-public class IgniteBaseDAOCosmosDBIntegrationTest {
-
+@TestPropertySource("/ignite-dao-documentdb.properties")
+public class IgniteBaseDAODocumentDBIntegrationTest {
     private static final String SOURCEDEVICEID = "sourceDeviceId";
 
     @Autowired
@@ -122,8 +121,8 @@ public class IgniteBaseDAOCosmosDBIntegrationTest {
     @Before
     public void setupEcallDAO() throws IOException {
         Properties daoProperties = new Properties();
-        daoProperties.load(IgniteBaseDAOCosmosDBIntegrationTest.class.getResourceAsStream(
-                "/ignite-dao-cosmosdb.properties"));
+        daoProperties.load(IgniteBaseDAODocumentDBIntegrationTest.class.getResourceAsStream(
+                "/ignite-dao-documentdb.properties"));
     }
 
     @Test
@@ -143,7 +142,7 @@ public class IgniteBaseDAOCosmosDBIntegrationTest {
         assertNotNull(ecall.getLastUpdatedTime());
         Assert.assertTrue(ecall.getLastUpdatedTime().isBefore(LocalDateTime.now()));
     }
-
+    
     @Test
     public void testSaveAll() {
         ECallEvent ecall1 = new ECallEvent();
@@ -361,13 +360,13 @@ public class IgniteBaseDAOCosmosDBIntegrationTest {
         igniteQuery = new IgniteQuery(icg);
         boolean duplicateKeyException = false;
         try {
-            ecallDao.upsert(igniteQuery, ecall3);
+            upsertFlag = ecallDao.upsert(igniteQuery, ecall3);
         } catch (Exception dke) {
             if (dke instanceof MongoWriteException) {
                 duplicateKeyException = true;
             }
         }
-        ecallDao.findByIds("ECallIdAll_1");
+        ecallEventList = ecallDao.findByIds("ECallIdAll_1");
         Assert.assertTrue(duplicateKeyException);
     }
 
@@ -793,6 +792,8 @@ public class IgniteBaseDAOCosmosDBIntegrationTest {
         ecall.setTimestamp(NumericConstants.TIMESTAMP);
         ecall.setVehicleId("Vehicle_1");
         ecall.setVersion(org.eclipse.ecsp.domain.Version.V1_0);
+        BytesBuffer buffer = new BytesBuffer("Test".getBytes());
+        //ecall.setBytesBuffer(buffer);
         ecallDao.save(ecall);
         ECallEvent ecallOut = ecallDao.findById("ECallId_ByteBuffer1");
         assertEquals("Error in converting ByteBuffer", ecall.getBytesBuffer(), ecallOut.getBytesBuffer());
@@ -860,7 +861,7 @@ public class IgniteBaseDAOCosmosDBIntegrationTest {
         au1.setCreatedOn(LocalDateTime.now());
         au1.setUpdatedOn(LocalDateTime.now());
 
-        ArrayList<AuthUsers> aus = new ArrayList<AuthUsers>();
+        ArrayList<ECallEvent.AuthUsers> aus = new ArrayList<ECallEvent.AuthUsers>();
         aus.add(au1);
         aus.add(au2);
         ecall.setAuthorizedUsers(aus);
@@ -905,7 +906,7 @@ public class IgniteBaseDAOCosmosDBIntegrationTest {
         au2.setCreatedOn(LocalDateTime.now());
         au2.setUpdatedOn(LocalDateTime.now());
 
-        ArrayList<AuthUsers> aus = new ArrayList<AuthUsers>();
+        ArrayList<ECallEvent.AuthUsers> aus = new ArrayList<ECallEvent.AuthUsers>();
         aus.add(au1);
         aus.add(au2);
         ecall.setAuthorizedUsers(aus);
@@ -953,7 +954,7 @@ public class IgniteBaseDAOCosmosDBIntegrationTest {
         au2.setCreatedOn(LocalDateTime.now());
         au2.setUpdatedOn(LocalDateTime.now());
 
-        ArrayList<AuthUsers> aus = new ArrayList<AuthUsers>();
+        ArrayList<ECallEvent.AuthUsers> aus = new ArrayList<ECallEvent.AuthUsers>();
         aus.add(au1);
         aus.add(au2);
         ecall.setAuthorizedUsers(aus);
@@ -999,10 +1000,10 @@ public class IgniteBaseDAOCosmosDBIntegrationTest {
         au3.setCreatedOn(LocalDateTime.now());
         au3.setUpdatedOn(LocalDateTime.now());
 
-        ArrayList<AuthUsers> aus = new ArrayList<AuthUsers>();
+        ArrayList<ECallEvent.AuthUsers> aus = new ArrayList<ECallEvent.AuthUsers>();
         aus.add(au1);
         aus.add(au2);
-        ArrayList<AuthUsers> aus1 = new ArrayList<AuthUsers>();
+        ArrayList<ECallEvent.AuthUsers> aus1 = new ArrayList<ECallEvent.AuthUsers>();
         aus1.add(au3);
 
         ECallEvent ecall = new ECallEvent();
@@ -1222,7 +1223,7 @@ public class IgniteBaseDAOCosmosDBIntegrationTest {
     public void testIndexCreation() {
         dao.deleteAll();
         TestEvent event = new TestEvent();
-        event.setManufacturer("dummyMfr");
+        event.setManufacturer("audi");
         event.setModel("A3");
         event.setYear("1992");
         event.setPrice(NumericConstants.PRICE);

--- a/src/test/java/org/eclipse/ecsp/nosqldao/mongodb/IgniteBaseDAOMongoImplMockTest.java
+++ b/src/test/java/org/eclipse/ecsp/nosqldao/mongodb/IgniteBaseDAOMongoImplMockTest.java
@@ -40,13 +40,20 @@
 
 package org.eclipse.ecsp.nosqldao.mongodb;
 
+import com.mongodb.MongoCommandException;
 import com.mongodb.MongoNamespace;
+import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
 import dev.morphia.AdvancedDatastore;
 import dev.morphia.mapping.Mapper;
 import dev.morphia.query.Query;
 import dev.morphia.query.UpdateOperations;
 import dev.morphia.query.internal.MorphiaCursor;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
 import org.eclipse.ecsp.nosqldao.IgniteCriteria;
 import org.eclipse.ecsp.nosqldao.IgniteCriteriaGroup;
 import org.eclipse.ecsp.nosqldao.IgniteQuery;
@@ -57,6 +64,7 @@ import org.eclipse.ecsp.nosqldao.ecall.ECallDAOMongoImpl;
 import org.eclipse.ecsp.nosqldao.ecall.ECallEvent;
 import org.eclipse.ecsp.nosqldao.ecall.MockTestDAOMongoImpl;
 import org.eclipse.ecsp.nosqldao.ecall.MockTestEvent;
+import org.eclipse.ecsp.nosqldao.utils.NumericConstants;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -69,8 +77,12 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.Optional;
 
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.eq;
 
 /**
@@ -100,6 +112,9 @@ public class IgniteBaseDAOMongoImplMockTest {
     private MongoCollection mongoCollection;
 
     @Mock
+    private MongoDatabase mongoDatabase;
+
+    @Mock
     private MongoNamespace namespace;
 
     @Mock
@@ -118,12 +133,13 @@ public class IgniteBaseDAOMongoImplMockTest {
      */
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         collection = testDAOMongoImpl.getOverridingCollectionName();
         Mockito.when(ds.getMapper()).thenReturn(mapper);
         Mockito.when(mapper.getCollection(Mockito.any())).thenReturn(mongoCollection);
         Mockito.when(mongoCollection.getNamespace()).thenReturn(namespace);
         Mockito.when(namespace.getCollectionName()).thenReturn(collection);
+        Mockito.when(ds.getDatabase()).thenReturn(mongoDatabase);
     }
 
     @Test
@@ -202,6 +218,131 @@ public class IgniteBaseDAOMongoImplMockTest {
     public void testDistinct() {
         IgniteQuery igniteQuery = new IgniteQuery();
         testDAOMongoImpl.distinct(igniteQuery, "id");
+    }
+
+    @Test
+    public void testSafeCreateCollection_SwallowsNamespaceExists() throws Exception {
+        // Arrange: create a real MongoCommandException with code 48 (NamespaceExists)
+        BsonDocument response = new BsonDocument()
+                .append("ok", new BsonDouble(0.0))
+                .append("code", new BsonInt32(NumericConstants.FORTY_EIGHT))
+                .append("errmsg", new BsonString("NamespaceExists"));
+        MongoCommandException namespaceExists = new MongoCommandException(
+            response, new ServerAddress("localhost", NumericConstants.MONGO_HOST));
+        Mockito.doThrow(namespaceExists).when(mongoDatabase).createCollection("testColl");
+
+        // Act: invoke private method via reflection
+        Method m = testDAOMongoImpl.getClass().getSuperclass().getDeclaredMethod("safeCreateCollection", String.class);
+        m.setAccessible(true);
+        m.invoke(testDAOMongoImpl, "testColl");
+
+        // Assert: method completed without exception and createCollection was called once
+        Mockito.verify(mongoDatabase, Mockito.times(1)).createCollection("testColl");
+    }
+
+    @Test
+    public void testSafeCreateCollection_CreatesWhenAbsent() throws Exception {
+        // Arrange: default behavior (no exception)
+
+        // Act
+        Method m = testDAOMongoImpl.getClass().getSuperclass().getDeclaredMethod("safeCreateCollection", String.class);
+        m.setAccessible(true);
+        m.invoke(testDAOMongoImpl, "newColl");
+
+        // Assert
+        Mockito.verify(mongoDatabase, Mockito.times(1)).createCollection("newColl");
+    }
+
+    @Test
+    public void testBackoff_SleepsProportionally() throws Exception {
+        // Arrange: set base backoff to 20ms
+        Field f = testDAOMongoImpl.getClass().getSuperclass().getDeclaredField("indexEnsureBackoffBaseMs");
+        f.setAccessible(true);
+        f.setLong(testDAOMongoImpl, NumericConstants.LONG_TWENTY);
+
+        Method backoff = testDAOMongoImpl.getClass().getSuperclass().getDeclaredMethod("backoff", int.class);
+        backoff.setAccessible(true);
+
+        long start = System.nanoTime();
+        // Act: attempt=2 => expected sleep ~40ms
+        backoff.invoke(testDAOMongoImpl, NumericConstants.TWO);
+        long elapsedMs = Duration.ofNanos(System.nanoTime() - start).toMillis();
+
+        // Assert: Allow some jitter; ensure at least ~30ms (less than 40 to avoid flakiness)
+        Assert.assertTrue("Backoff did not sleep long enough: " 
+            + elapsedMs + "ms", elapsedMs >= NumericConstants.THIRTY);
+    }
+
+    @Test
+    public void testEnsureIndexesWithRetry_ThrowsOnNonRetryable() throws Exception {
+        // Arrange: non-retryable MongoCommandException (e.g., code 2)
+        BsonDocument response = new BsonDocument()
+                .append("ok", new BsonDouble(0.0))
+                .append("code", new BsonInt32(NumericConstants.TWO))
+                .append("errmsg", new BsonString("SomeNonRetryableError"));
+        final MongoCommandException nonRetryable = new MongoCommandException(
+            response, new ServerAddress("localhost", NumericConstants.MONGO_HOST));
+
+        Runnable indexCreationAction = () -> { 
+            throw nonRetryable; 
+        };
+
+        Method m = testDAOMongoImpl.getClass().getSuperclass().getDeclaredMethod(
+            "ensureIndexesWithRetry", String.class, Runnable.class);
+        m.setAccessible(true);
+
+        try {
+            m.invoke(testDAOMongoImpl, "nonRetryColl", indexCreationAction);
+            Assert.fail("Expected MongoCommandException to be thrown");
+        } catch (java.lang.reflect.InvocationTargetException ite) {
+            Throwable cause = ite.getCause();
+            Assert.assertTrue(cause instanceof MongoCommandException);
+            Assert.assertEquals(NumericConstants.TWO, ((MongoCommandException) cause).getErrorCode());
+        }
+
+        // Verify no collection creation for non-retryable errors
+        Mockito.verify(mongoDatabase, Mockito.never()).createCollection(Mockito.anyString());
+    }
+
+    @Test
+    public void testEnsureIndexesWithRetry_ExhaustsRetriesThenThrows() throws Exception {
+        // Arrange: retryable error code 26; force small backoff and 2 attempts
+        Field attemptsField = testDAOMongoImpl.getClass().getSuperclass().getDeclaredField(
+            "indexEnsureMaxAttempts");
+        attemptsField.setAccessible(true);
+        attemptsField.setInt(testDAOMongoImpl, NumericConstants.TWO);
+
+        Field backoffField = testDAOMongoImpl.getClass().getSuperclass().getDeclaredField(
+            "indexEnsureBackoffBaseMs");
+        backoffField.setAccessible(true);
+        backoffField.setLong(testDAOMongoImpl, NumericConstants.LONG_ONE);
+
+        BsonDocument response = new BsonDocument()
+                .append("ok", new BsonDouble(0.0))
+                .append("code", new BsonInt32(NumericConstants.TWENTY_SIX))
+                .append("errmsg", new BsonString("NamespaceNotFound"));
+        final MongoCommandException retryable = new MongoCommandException(
+            response, new ServerAddress("localhost", NumericConstants.MONGO_HOST));
+
+        Runnable indexCreationAction = () -> { 
+            throw retryable; 
+        };
+
+        Method m = testDAOMongoImpl.getClass().getSuperclass().getDeclaredMethod(
+            "ensureIndexesWithRetry", String.class, Runnable.class);
+        m.setAccessible(true);
+
+        try {
+            m.invoke(testDAOMongoImpl, "retryColl", indexCreationAction);
+            Assert.fail("Expected MongoCommandException to be thrown after exhausting retries");
+        } catch (java.lang.reflect.InvocationTargetException ite) {
+            Throwable cause = ite.getCause();
+            Assert.assertTrue(cause instanceof MongoCommandException);
+            Assert.assertEquals(NumericConstants.TWENTY_SIX, ((MongoCommandException) cause).getErrorCode());
+        }
+
+        // Verify collection creation was attempted once due to retry path
+        Mockito.verify(mongoDatabase, Mockito.atLeastOnce()).createCollection("retryColl");
     }
 
 }

--- a/src/test/java/org/eclipse/ecsp/nosqldao/spring/config/AbstractIgniteDAOMongoConfigTest.java
+++ b/src/test/java/org/eclipse/ecsp/nosqldao/spring/config/AbstractIgniteDAOMongoConfigTest.java
@@ -47,6 +47,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.concurrent.TimeUnit;
@@ -62,9 +63,12 @@ public class AbstractIgniteDAOMongoConfigTest {
     @InjectMocks
     AbstractIgniteDAOMongoConfig igniteDAOMongoConfig = new IgniteDAOMongoConfigWithProps();
 
+    @Mock
+    private CustomConnectionPoolListener customConnectionPoolListener;
+
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
     }
 
     @Test
@@ -83,6 +87,7 @@ public class AbstractIgniteDAOMongoConfigTest {
         igniteDAOMongoConfig.maxWaitTime = NumericConstants.SIXTY_K;
         igniteDAOMongoConfig.hosts = "localhost";
         igniteDAOMongoConfig.maintenanceInitialDelay = NumericConstants.THIRTY_K;
+        igniteDAOMongoConfig.readPreference = "secondaryPreferred";
         igniteDAOMongoConfig.noSqlDatabaseType = NoSqlDatabaseType.MONGODB;
         MongoClientSettings.Builder mongoClientSettingsBuilder = igniteDAOMongoConfig
                 .createMongoClientSettingsBuilder();
@@ -114,6 +119,7 @@ public class AbstractIgniteDAOMongoConfigTest {
         igniteDAOMongoConfig.hosts = "localhost";
         igniteDAOMongoConfig.maxConnectionsPerHost = NumericConstants.TWO;
         igniteDAOMongoConfig.noSqlDatabaseType = NoSqlDatabaseType.MONGODB;
+        igniteDAOMongoConfig.readPreference = "secondaryPreferred";
         igniteDAOMongoConfig.morphiaConverters = "org.eclipse.ecsp.nosqldao.mongodb.BytesBufferConverter";
         MongoClientSettings.Builder mongoClientSettingsBuilder = igniteDAOMongoConfig
                 .createMongoClientSettingsBuilder();
@@ -145,12 +151,12 @@ public class AbstractIgniteDAOMongoConfigTest {
         igniteDAOMongoConfig.hosts = "localhost";
         igniteDAOMongoConfig.maxConnectionsPerHost = NumericConstants.TWO;
         igniteDAOMongoConfig.noSqlDatabaseType = NoSqlDatabaseType.MONGODB;
+        igniteDAOMongoConfig.readPreference = "secondaryPreferred";
         igniteDAOMongoConfig.morphiaConverters = "org.eclipse.ecsp.nosqldao.mongodb.BytesBufferConvert";
         MongoClientSettings.Builder mongoClientSettingsBuilder = igniteDAOMongoConfig
                 .createMongoClientSettingsBuilder();
         Assert.assertEquals(NumericConstants.TWO, mongoClientSettingsBuilder.build()
                 .getConnectionPoolSettings().getMaxConnecting());
-
     }
 
     @Test
@@ -165,5 +171,31 @@ public class AbstractIgniteDAOMongoConfigTest {
         igniteDAOMongoConfig.readPreference = "secondaryPreferred";
         igniteDAOMongoConfig.noSqlDatabaseType = NoSqlDatabaseType.MONGODB;
         assertThrows(RuntimeException.class, () -> igniteDAOMongoConfig.getDatastore());
+    }
+
+    @Test
+    public void testGetDatastoreDbNameForMongoDb() throws Exception {
+        igniteDAOMongoConfig.dbName = "mongoDb";
+        igniteDAOMongoConfig.docDbName = "docDb";
+        igniteDAOMongoConfig.noSqlDatabaseType = NoSqlDatabaseType.MONGODB;
+
+        java.lang.reflect.Method m = AbstractIgniteDAOMongoConfig.class.getDeclaredMethod("getDatastoreDbName");
+        m.setAccessible(true);
+        String name = (String) m.invoke(igniteDAOMongoConfig);
+
+        assertEquals("mongoDb", name);
+    }
+
+    @Test
+    public void testGetDatastoreDbNameForDocumentDb() throws Exception {
+        igniteDAOMongoConfig.dbName = "mongoDb";
+        igniteDAOMongoConfig.docDbName = "docDb";
+        igniteDAOMongoConfig.noSqlDatabaseType = NoSqlDatabaseType.DOCUMENTDB;
+
+        java.lang.reflect.Method m = AbstractIgniteDAOMongoConfig.class.getDeclaredMethod("getDatastoreDbName");
+        m.setAccessible(true);
+        String name = (String) m.invoke(igniteDAOMongoConfig);
+
+        assertEquals("docDb", name);
     }
 }

--- a/src/test/resources/ignite-dao-documentdb.properties
+++ b/src/test/resources/ignite-dao-documentdb.properties
@@ -1,0 +1,20 @@
+morphia.map.packages=com.harman
+#Comma separated fully qualified names for Morphia converters
+morphia.converters.fqn=com.harman.ignite.dao.mongodb.BytesBufferConverter,com.harman.ignite.dao.mongodb.TestBufferConverter,com.harman.ignite.dao.mongodb.TestEntityCodec,com.harman.ignite.dao.mongodb.TestEntityCodec2
+
+morphia.discriminator.key=className
+
+health.mongo.monitor.enabled=true
+health.mongo.needs.restart.on.failure=true
+metrics.prometheus.enabled=false
+metrics.dao.enabled=false
+service.name=test
+
+no.sql.database.type=documentDB
+documentdb.name=test
+documentdb.auth.db=test
+documentdb.host=analytics-docdb-236907965461.us-east-1.docdb-elastic.amazonaws.com
+documentdb.port=27017
+documentdb.username=analyticsdoc
+documentdb.password=s.UV1ltuLIlsDI4wKrafkTDwK6
+documentdb.connection.params=tls=true&authenticationMechanism=SCRAM-SHA-1&retryWrites=false&readpreference=secondaryPreferred


### PR DESCRIPTION
Resolves #21 

----
### Describe behaviour before the change
* Existing support was available only for CosmosDB and MongoDB

### Describe behaviour after the change
* Added support for and integration with DocumentDB, exposing documentDB specific configurations and vault intergration.

### Pull request checklist
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All new and existing tests passed.
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
- [ ] Yes
- [x] No

----

